### PR TITLE
Release v0.2.3

### DIFF
--- a/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/Base64GuidBenchmarks.cs
+++ b/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/Base64GuidBenchmarks.cs
@@ -1,0 +1,47 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace TehGM.Utilities.UniqueIDs.Benchmarks
+{
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkDotNet.Configs.BenchmarkLogicalGroupRule.ByJob)]
+    public class Base64GuidBenchmarks
+    {
+        private Base64Guid _value;
+        private string _guidDisplayValue;
+        private string _trimmedDisplayValue;
+        private string _untrimmedDisplayValue;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            this._value = Base64Guid.GenerateNew();
+            this._guidDisplayValue = this._value.Value.ToString();
+            this._trimmedDisplayValue = this._value.ToString();
+            this._untrimmedDisplayValue = this._trimmedDisplayValue + "==";
+        }
+
+        [Benchmark]
+        public void Base64Guid_Parse_FromGuid()
+        {
+            Base64Guid value = Base64Guid.Parse(this._guidDisplayValue);
+        }
+
+        [Benchmark]
+        public void Base64Guid_Parse_FromTrimmedDisplayValue()
+        {
+            Base64Guid value = Base64Guid.Parse(this._trimmedDisplayValue);
+        }
+
+        [Benchmark]
+        public void Base64Guid_Parse_FromUnrimmedDisplayValue()
+        {
+            Base64Guid value = Base64Guid.Parse(this._untrimmedDisplayValue);
+        }
+
+        [Benchmark]
+        public void Base64Guid_ToString()
+        {
+            string value = this._value.ToString();
+        }
+    }
+}

--- a/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/Program.cs
+++ b/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/Program.cs
@@ -1,0 +1,29 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace TehGM.Utilities.UniqueIDs.Benchmarks
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            ManualConfig config = ManualConfig.CreateMinimumViable()
+                .AddJob(Job.Default
+                    .AsBaseline()
+                    .WithRuntime(CoreRuntime.Core60)
+                    .WithPlatform(Platform.X64)
+                    .WithGcServer(true))
+                .AddJob(Job.Default
+                    .AsBaseline()
+                    .WithRuntime(CoreRuntime.Core80)
+                    .WithPlatform(Platform.X64)
+                    .WithGcServer(true))
+                .WithOptions(ConfigOptions.DisableLogFile)
+                .WithOptions(ConfigOptions.DisableOptimizationsValidator);
+
+            BenchmarkRunner.Run(typeof(Program).Assembly, config, args);
+        }
+    }
+}

--- a/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks.csproj
+++ b/Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks/TehGM.Utilities.UniqueIDs.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\TehGM.Utilities.UniqueIDs\TehGM.Utilities.UniqueIDs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TehGM.Utilities.Randomization/IRandomizer.cs
+++ b/TehGM.Utilities.Randomization/IRandomizer.cs
@@ -3,7 +3,7 @@
     /// <summary>Represents random number generator as a service.</summary>
     public interface IRandomizer
     {
-        /// <summary>Gets a random integer.</summary>
+        /// <summary>Gets a random 32-bit integer.</summary>
         /// <param name="min">Minimum value.</param>
         /// <param name="max">Maximum value.</param>
         /// <param name="inclusive">Whether <paramref name="max"/> is inclusive.</param>
@@ -14,5 +14,18 @@
         /// <param name="max">Maximum value.</param>
         /// <returns>A randomly generated number.</returns>
         double GetRandomNumber(double min, double max);
+#if NET6_0_OR_GREATER
+        /// <summary>Gets a random 64-bit integer.</summary>
+        /// <param name="min">Minimum value.</param>
+        /// <param name="max">Maximum value.</param>
+        /// <param name="inclusive">Whether <paramref name="max"/> is inclusive.</param>
+        /// <returns>A randomly generated number.</returns>
+        long GetRandomNumber(long min, long max, bool inclusive = false);
+        /// <summary>Gets a random float.</summary>
+        /// <param name="min">Minimum value.</param>
+        /// <param name="max">Maximum value.</param>
+        /// <returns>A randomly generated number.</returns>
+        float GetRandomNumber(float min, float max);
+#endif
     }
 }

--- a/TehGM.Utilities.Randomization/RandomExtensions.cs
+++ b/TehGM.Utilities.Randomization/RandomExtensions.cs
@@ -49,7 +49,7 @@ namespace TehGM.Utilities.Randomization
             Type t = typeof(T);
             if (!t.IsEnum)
                 throw new InvalidOperationException($"{nameof(GetRandomEnumValue)} can only be used on enums. {t.Name} is not an enum");
-#if NET5_0
+#if NET5_0_OR_GREATER
             T[] values = Enum.GetValues<T>();
 #else
             IEnumerable<T> values = Enum.GetValues(t).Cast<T>();
@@ -76,7 +76,11 @@ namespace TehGM.Utilities.Randomization
             if (length == 0)
                 return string.Empty;
 
+#if NET7_0_OR_GREATER
+            Span<char> chars = stackalloc char[length];
+#else
             char[] chars = new char[length];
+#endif
             for (int i = 0; i < length; i++)
                 chars[i] = charset[random.Next(0, charset.Length)];
 

--- a/TehGM.Utilities.Randomization/RandomizerExtensions.cs
+++ b/TehGM.Utilities.Randomization/RandomizerExtensions.cs
@@ -84,7 +84,11 @@ namespace TehGM.Utilities.Randomization
             if (length == 0)
                 return string.Empty;
 
+#if NET7_0_OR_GREATER
+            Span<char> chars = stackalloc char[length];
+#else
             char[] chars = new char[length];
+#endif
             for (int i = 0; i < length; i++)
                 chars[i] = charset[randomizer.GetRandomNumber(0, charset.Length, false)];
 

--- a/TehGM.Utilities.Randomization/Services/RandomizerService.cs
+++ b/TehGM.Utilities.Randomization/Services/RandomizerService.cs
@@ -31,5 +31,21 @@
             double range = max - min;
             return min + this._random.NextDouble() * range;
         }
+
+#if NET6_0_OR_GREATER
+        /// <inheritdoc/>
+        public long GetRandomNumber(long min, long max, bool inclusive)
+        {
+            max = (inclusive) ? ++max : max;
+            return this._random.NextInt64(min, max);
+        }
+
+        /// <inheritdoc/>
+        public float GetRandomNumber(float min, float max)
+        {
+            float range = max - min;
+            return min + this._random.NextSingle() * range;
+        }
+#endif
     }
 }

--- a/TehGM.Utilities.Randomization/TehGM.Utilities.Randomization.csproj
+++ b/TehGM.Utilities.Randomization/TehGM.Utilities.Randomization.csproj
@@ -2,7 +2,7 @@
 	
 	<PropertyGroup>
 		<PackageId>TehGM.Utilities.Randomization</PackageId>
-		<TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
 		<RootNamespace>TehGM.Utilities</RootNamespace>
 		<Version>0.2.2</Version>
 		<Authors>TehGM</Authors>

--- a/TehGM.Utilities.Randomization/TehGM.Utilities.Randomization.csproj
+++ b/TehGM.Utilities.Randomization/TehGM.Utilities.Randomization.csproj
@@ -4,7 +4,7 @@
 		<PackageId>TehGM.Utilities.Randomization</PackageId>
 		<TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
 		<RootNamespace>TehGM.Utilities</RootNamespace>
-		<Version>0.2.2</Version>
+		<Version>0.2.3</Version>
 		<Authors>TehGM</Authors>
 		<Product>TehGM's Utilities Library - Randomization</Product>
 		<RepositoryUrl>https://github.com/TehGM/TehGM.Utilities</RepositoryUrl>
@@ -18,7 +18,10 @@
 		<RepositoryType>git</RepositoryType>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageReleaseNotes>- Fix multi-targetting compilation for .NET6+.</PackageReleaseNotes>
+		<PackageReleaseNotes>
+- Add support for long and float-based random number generation (.NET 6+).
+- Minor performance and heap allocation optimization for random string on .NET 7+.
+		</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/TehGM.Utilities.UniqueIDs/Base64Guid.cs
+++ b/TehGM.Utilities.UniqueIDs/Base64Guid.cs
@@ -34,6 +34,7 @@ namespace TehGM.Utilities
         /// <param name="value">Display value of the GUID.</param>
         /// <exception cref="ArgumentNullException">Given value is null.</exception>
         /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        [Obsolete("Use Parse method instead.")]
         public Base64Guid(string value)
         {
             if (value == null)
@@ -51,6 +52,7 @@ namespace TehGM.Utilities
         /// <param name="value">Display value of the GUID.</param>
         /// <exception cref="ArgumentNullException">Given value is null.</exception>
         /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        [Obsolete("Use Parse method instead.")]
         public Base64Guid(ReadOnlySpan<char> value)
         {
             this._value = ConvertStringToGuid(value);
@@ -295,7 +297,7 @@ namespace TehGM.Utilities
             => this._value.Equals(other);
         /// <inheritdoc/>
         public bool Equals(string other)
-            => this.Equals(new Base64Guid(other));
+            => this.Equals(Parse(other));
         /// <inheritdoc/>
         public override int GetHashCode()
             => -1937169414 + this._value.GetHashCode();
@@ -334,6 +336,6 @@ namespace TehGM.Utilities
         /// <summary>Converts string representation ID to base64 guid wrapper.</summary>
         /// <param name="value">Base64 wrapped guid.</param>
         public static implicit operator Base64Guid(string value)
-            => new Base64Guid(value);
+            => Parse(value);
     }
 }

--- a/TehGM.Utilities.UniqueIDs/Base64Guid.cs
+++ b/TehGM.Utilities.UniqueIDs/Base64Guid.cs
@@ -71,7 +71,7 @@ namespace TehGM.Utilities
 #else
 
             if (!IsLengthValid(value.Length))
-                throw new FormatException("A valid DisplayGuid string is either 22 or 24 characters long");
+                throw new FormatException("A valid Base64Guid string is either 22 or 24 characters long");
             if (value.Length == _trimmedLength)
                 value += "==";
 
@@ -90,7 +90,7 @@ namespace TehGM.Utilities
         private static Guid ConvertStringToGuid(ReadOnlySpan<char> value)
         {
             if (!IsLengthValid(value.Length))
-                throw new FormatException("A valid DisplayGuid string is either 22 or 24 characters long");
+                throw new FormatException("A valid Base64Guid string is either 22 or 24 characters long");
 
             Span<char> result = stackalloc char[24];
 

--- a/TehGM.Utilities.UniqueIDs/Base64Guid.cs
+++ b/TehGM.Utilities.UniqueIDs/Base64Guid.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using TehGM.Utilities.ComponentModel;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Buffers.Text;
+#endif
 
 namespace TehGM.Utilities
 {
@@ -12,17 +16,18 @@ namespace TehGM.Utilities
         , IParsable<Base64Guid>, ISpanParsable<Base64Guid>
 #endif
     {
-        private const int _packedLength = 22;
-        private const int _unpackedLength = 24;
+        private const int _trimmedLength = 22;
+        private const int _untrimmedLength = 24;
 
         /// <summary>The actual GUID value.</summary>
-        public Guid Value { get; }
+        public Guid Value => this._value;
+        private Guid _value;
 
         /// <summary>Wraps GUID into a new Base64Guid.</summary>
         /// <param name="value">Actual GUID value.</param>
         public Base64Guid(Guid value)
         {
-            this.Value = value;
+            this._value = value;
         }
 
         /// <summary>Creates a Base64Guid from a display value.</summary>
@@ -35,40 +40,78 @@ namespace TehGM.Utilities
                 throw new ArgumentNullException(nameof(value));
 
             value = value.Trim();
-            if (!IsLengthValid(value))
+            if (!IsLengthValid(value.Length))
                 throw new FormatException("A valid DisplayGuid string is either 22 or 24 characters long");
 
-            value = this.Unpack(value);
-            byte[] valueBytes = Convert.FromBase64String(value);
-            this.Value = new Guid(valueBytes);
+            this._value = ConvertStringToGuid(value);
         }
+
+#if NET7_0_OR_GREATER
+        /// <summary>Creates a Base64Guid from a display value.</summary>
+        /// <param name="value">Display value of the GUID.</param>
+        /// <exception cref="ArgumentNullException">Given value is null.</exception>
+        /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        public Base64Guid(ReadOnlySpan<char> value)
+        {
+            this._value = ConvertStringToGuid(value);
+        }
+#endif
 
         /// <summary>Generates a new GUID wrapped into a Base64Guid.</summary>
         /// <returns>A new display guid.</returns>
         public static Base64Guid GenerateNew()
             => new Base64Guid(Guid.NewGuid());
 
-        private string Unpack(string value)
+        private static Guid ConvertStringToGuid(string value)
         {
-            if (value.Length == _packedLength)
+#if NET7_0_OR_GREATER
+            return ConvertStringToGuid(value.AsSpan());
+#else
+
+            if (!IsLengthValid(value.Length))
+                throw new FormatException("A valid DisplayGuid string is either 22 or 24 characters long");
+            if (value.Length == _trimmedLength)
                 value += "==";
 
             value = value.Replace('-', '+');
             value = value.Replace('_', '/');
 
-            return value;
+            byte[] valueBytes = Convert.FromBase64String(value);
+            return new Guid(valueBytes);
+#endif
         }
 
-        private string Pack(string value)
+#if NET7_0_OR_GREATER
+        // gotta give credit where it's due:
+        // span-based implementation heavily based on Nick Chapsas' video
+        // https://www.youtube.com/watch?v=B2yOjLyEZk0
+        private static Guid ConvertStringToGuid(ReadOnlySpan<char> value)
         {
-            if (value.Length == _unpackedLength)
-                value = value.Remove(_packedLength);
+            if (!IsLengthValid(value.Length))
+                throw new FormatException("A valid DisplayGuid string is either 22 or 24 characters long");
 
-            value = value.Replace('+', '-');
-            value = value.Replace('/', '_');
+            Span<char> result = stackalloc char[24];
 
-            return value;
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                result[i] = c switch
+                {
+                    '-' => '+',
+                    '_' => '/',
+                    _ => c
+                };
+            }
+
+            result[22] = '=';
+            result[23] = '=';
+
+            Span<byte> resultBytes = stackalloc byte[16];
+            if (!Convert.TryFromBase64Chars(result, resultBytes, out _))
+                throw new FormatException("The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.");
+            return new Guid(resultBytes);
         }
+#endif
 
         /// <summary>Converts the string representation of a Guid or Base64Guid to a Base64Guid instance.</summary>
         /// <param name="value">String representation of a Guid or Base64Guid.</param>
@@ -89,17 +132,16 @@ namespace TehGM.Utilities
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            value = value.Trim();
 #if NET7_0_OR_GREATER
-            if (Guid.TryParse(value, provider, out Guid guidResult))
+            return Parse(value.AsSpan(), provider);
 #else
-            if (Guid.TryParse(value, out Guid guidResult))
+            value = value.Trim();
+            if (!Guid.TryParse(value, out Guid guidResult))
+                guidResult = ConvertStringToGuid(value);
+            return new Base64Guid(guidResult);
 #endif
-                return guidResult;
-
-            return ParseDirect(value, provider);
         }
-        
+
 #if NET7_0_OR_GREATER
         /// <summary>Converts the string representation of a Guid or Base64Guid to a Base64Guid instance.</summary>
         /// <param name="value">The span of characters to parse.</param>
@@ -110,15 +152,12 @@ namespace TehGM.Utilities
         public static Base64Guid Parse(ReadOnlySpan<char> value, IFormatProvider provider)
         {
             value = value.Trim();
-            if (Guid.TryParse(value, provider, out Guid guidResult))
-                return guidResult;
+            if (!Guid.TryParse(value, provider, out Guid guidResult))
+                guidResult = ConvertStringToGuid(value);
 
-            return Parse(value.ToString(), provider);
+            return new Base64Guid(guidResult);
     }
 #endif
-
-        private static Base64Guid ParseDirect(string value, IFormatProvider provider)
-            => new Base64Guid(value);
 
         /// <summary>Attempts to convert the string representation of a Guid or Base64Guid to a Base64Guid instance.</summary>
         /// <param name="value">String representation of a Guid or Base64Guid.</param>
@@ -132,17 +171,38 @@ namespace TehGM.Utilities
         /// <param name="result">Display value of the GUID.</param>
         public static bool TryParse(string value, IFormatProvider provider, out Base64Guid result)
         {
+            if (value == null)
+            {
+                result = default;
+                return false;
+            }
+
 #if NET7_0_OR_GREATER
-            if (Guid.TryParse(value, provider, out Guid guidResult))
+            return TryParse(value.AsSpan(), provider, out result);
 #else
             if (Guid.TryParse(value, out Guid guidResult))
-#endif
             {
                 result = guidResult;
                 return true;
             }
-
-            return TryParseDirect(value, out result);
+            
+            value = value.Trim();
+            if (!IsLengthValid(value.Length))
+            {
+                result = default;
+                return false;
+            }
+            try
+            {
+                result = Parse(value, provider);
+                return true;
+            }
+            catch
+            {
+                result = default;
+                return false;
+            }
+#endif
         }
 
 #if NET7_0_OR_GREATER
@@ -158,21 +218,15 @@ namespace TehGM.Utilities
                 return true;
             }
 
-            return TryParseDirect(value.ToString(), out result);
-        }
-#endif
-
-        private static bool TryParseDirect(string value, out Base64Guid result)
-        {
-            value = value?.Trim();
-            if (!IsLengthValid(value))
+            value = value.Trim();
+            if (!IsLengthValid(value.Length))
             {
                 result = default;
                 return false;
             }
             try
             {
-                result = Parse(value);
+                result = Parse(value, provider);
                 return true;
             }
             catch
@@ -181,16 +235,44 @@ namespace TehGM.Utilities
                 return false;
             }
         }
+#endif
 
-        private static bool IsLengthValid(string value)
-            => value != null && (value.Length == _packedLength || value.Length == _unpackedLength);
+        private static bool IsLengthValid(int length)
+            => length == _trimmedLength || length == _untrimmedLength;
 
+        // gotta give credit where it's due:
+        // span-based implementation heavily based on Nick Chapsas' video
+        // https://www.youtube.com/watch?v=B2yOjLyEZk0
         /// <inheritdoc/>
         public override string ToString()
         {
+#if NET7_0_OR_GREATER
+            Span<byte> valueBytes = stackalloc byte[16];
+            Span<byte> resultBytes = stackalloc byte[24];
+            Span<char> result = stackalloc char[_trimmedLength];
+
+            MemoryMarshal.TryWrite(valueBytes, ref this._value);
+            Base64.EncodeToUtf8(valueBytes, resultBytes, out _, out _);
+
+            for (int i = 0; i < _trimmedLength; i++)
+            {
+                byte c = resultBytes[i];
+                result[i] = c switch
+                {
+                    (byte)'+' => '-',
+                    (byte)'/' => '_',
+                    _ => (char)c
+                };
+            }
+
+            return new string(result);
+#else
             string result = Convert.ToBase64String(this.Value.ToByteArray());
-            result = this.Pack(result);
+            result = result.Remove(_trimmedLength);
+            result = result.Replace('+', '-');
+            result = result.Replace('/', '_');
             return result;
+#endif
         }
 
         /// <inheritdoc/>
@@ -207,16 +289,16 @@ namespace TehGM.Utilities
 
         /// <inheritdoc/>
         public bool Equals(Base64Guid other)
-            => this.Equals(other.Value);
+            => this.Equals(other._value);
         /// <inheritdoc/>
         public bool Equals(Guid other)
-            => this.Value.Equals(other);
+            => this._value.Equals(other);
         /// <inheritdoc/>
         public bool Equals(string other)
             => this.Equals(new Base64Guid(other));
         /// <inheritdoc/>
         public override int GetHashCode()
-            => -1937169414 + this.Value.GetHashCode();
+            => -1937169414 + this._value.GetHashCode();
 
         /// <inheritdoc/>
         public static bool operator ==(Base64Guid left, Base64Guid right)
@@ -240,7 +322,7 @@ namespace TehGM.Utilities
         /// <summary>Converts base64 guid wrapper to a normal guid.</summary>
         /// <param name="value">Normal guid value.</param>
         public static implicit operator Guid(Base64Guid value)
-            => value.Value;
+            => value._value;
         /// <summary>Converts base64 guid wrapper to string representation.</summary>
         /// <param name="value">22 character string ID.</param>
         public static implicit operator string(Base64Guid value)

--- a/TehGM.Utilities.UniqueIDs/Base64Guid.cs
+++ b/TehGM.Utilities.UniqueIDs/Base64Guid.cs
@@ -47,18 +47,6 @@ namespace TehGM.Utilities
             this._value = ConvertStringToGuid(value);
         }
 
-#if NET7_0_OR_GREATER
-        /// <summary>Creates a Base64Guid from a display value.</summary>
-        /// <param name="value">Display value of the GUID.</param>
-        /// <exception cref="ArgumentNullException">Given value is null.</exception>
-        /// <exception cref="FormatException">Given value is in invalid format.</exception>
-        [Obsolete("Use Parse method instead.")]
-        public Base64Guid(ReadOnlySpan<char> value)
-        {
-            this._value = ConvertStringToGuid(value);
-        }
-#endif
-
         /// <summary>Generates a new GUID wrapped into a Base64Guid.</summary>
         /// <returns>A new display guid.</returns>
         public static Base64Guid GenerateNew()

--- a/TehGM.Utilities.UniqueIDs/Base64GuidConverter.cs
+++ b/TehGM.Utilities.UniqueIDs/Base64GuidConverter.cs
@@ -25,7 +25,7 @@ namespace TehGM.Utilities.ComponentModel
             if (value is Guid guid)
                 return new Base64Guid(guid);
             if (value is string str)
-                return new Base64Guid(str);
+                return Base64Guid.Parse(str);
             return base.ConvertFrom(context, culture, value);
         }
 

--- a/TehGM.Utilities.UniqueIDs/TehGM.Utilities.UniqueIDs.csproj
+++ b/TehGM.Utilities.UniqueIDs/TehGM.Utilities.UniqueIDs.csproj
@@ -4,7 +4,7 @@
 	  <PackageId>TehGM.Utilities.UniqueIDs</PackageId>
 	  <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
 	  <RootNamespace>TehGM.Utilities</RootNamespace>
-	  <Version>0.2.2</Version>
+	  <Version>0.2.3</Version>
 	  <Authors>TehGM</Authors>
 	  <Product>TehGM's Utilities Library - Unique IDs</Product>
 	  <RepositoryUrl>https://github.com/TehGM/TehGM.Utilities</RepositoryUrl>
@@ -19,8 +19,9 @@
 	  <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageReleaseNotes>
-- Added TypeConverter for Base64Guid.
-- Implement IParsable and ISpanParsable in Base64Guid (.NET7+).
+- Base64Guid constructor accepting string is now obsolete. Use Parse method instead.
+- Reduce heap allocations and improve performance of Base64Guid on .NET7+.
+- Fix wrong type named used in some of Base64Guid exception messages.
 	  </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/TehGM.Utilities.sln
+++ b/TehGM.Utilities.sln
@@ -43,9 +43,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TehGM.Utilities.Validation.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TehGM.Utilities.UniqueIDs.JsonNet", "JsonNet\TehGM.Utilities.UniqueIDs.JsonNet\TehGM.Utilities.UniqueIDs.JsonNet.csproj", "{8FB41CE5-5C2A-4354-B116-8AEB36B1AF74}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TehGM.Utilities.AspNetCore", "TehGM.Utilities.AspNetCore\TehGM.Utilities.AspNetCore.csproj", "{7A94AAE9-CDCF-4037-879C-6F147D9B1987}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TehGM.Utilities.AspNetCore", "TehGM.Utilities.AspNetCore\TehGM.Utilities.AspNetCore.csproj", "{7A94AAE9-CDCF-4037-879C-6F147D9B1987}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TehGM.Utilities.Threading", "TehGM.Utilities.Threading\TehGM.Utilities.Threading.csproj", "{B99F2E18-6609-4E5E-9F60-3AB71E6951E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TehGM.Utilities.Threading", "TehGM.Utilities.Threading\TehGM.Utilities.Threading.csproj", "{B99F2E18-6609-4E5E-9F60-3AB71E6951E1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{DFC53479-63D5-4034-BBF6-743C623D0600}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TehGM.Utilities.UniqueIDs.Benchmarks", "Benchmarks\TehGM.Utilities.UniqueIDs.Benchmarks\TehGM.Utilities.UniqueIDs.Benchmarks.csproj", "{3965C663-6C1D-4561-AE1F-D55771760142}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -113,6 +117,10 @@ Global
 		{B99F2E18-6609-4E5E-9F60-3AB71E6951E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B99F2E18-6609-4E5E-9F60-3AB71E6951E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B99F2E18-6609-4E5E-9F60-3AB71E6951E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3965C663-6C1D-4561-AE1F-D55771760142}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3965C663-6C1D-4561-AE1F-D55771760142}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3965C663-6C1D-4561-AE1F-D55771760142}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3965C663-6C1D-4561-AE1F-D55771760142}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +134,7 @@ Global
 		{6DE53A66-CEDC-447A-8CA6-9E361888B62A} = {730980FD-4811-4DC7-8EC5-D5BA6724C78A}
 		{29F85359-9C55-40DA-B10C-E663AFC8CB09} = {040A73CB-9C79-4305-91B4-DFC038F184DE}
 		{8FB41CE5-5C2A-4354-B116-8AEB36B1AF74} = {730980FD-4811-4DC7-8EC5-D5BA6724C78A}
+		{3965C663-6C1D-4561-AE1F-D55771760142} = {DFC53479-63D5-4034-BBF6-743C623D0600}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D7A9DC7-DD85-42FA-89BE-99FEFD7C10C4}

--- a/TehGM.Utilities/TehGM.Utilities.nuspec
+++ b/TehGM.Utilities/TehGM.Utilities.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>TehGM.Utilities</id>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <title>TehGM's C# Utilities</title>
     <authors>TehGM</authors>
     <owners>TehGM</owners>
@@ -14,17 +14,17 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>Copyright (c) 2022 TehGM</copyright>
     <releaseNotes>
-- UniqueIDs: Add TypeConverter for Base64Guid.
-- UniqueIDs: Implement IParsable and ISpanParsable for Base64Guid (.NET7+).
-- Time: Add TypeConverter for UnixTimestamp.
-- Time: Implement IParsable and ISpanParsable for UnixTimestamp (.NET7+).
-- Randomization: Fix multi-targetting compilation for .NET6+.
+- UniqueIDs: Base64Guid constructor accepting string is now obsolete. Use Parse method instead.
+- UniqueIDs: Reduce heap allocations and improve performance of Base64Guid on .NET7+.
+- UniqueIDs: Fix wrong type named used in some of Base64Guid exception messages.
+- Randomization: Add support for long and float-based random number generation (.NET 6+).
+- Randomization: Minor performance and heap allocation optimization for random string on .NET 7+.
 	</releaseNotes>
     <dependencies>
       <group>
-        <dependency id="TehGM.Utilities.UniqueID" version="0.2.2" />
+        <dependency id="TehGM.Utilities.UniqueID" version="0.2.3" />
         <dependency id="TehGM.Utilities.Logging" version="0.1.0" />
-        <dependency id="TehGM.Utilities.Randomization" version="0.2.2" />
+        <dependency id="TehGM.Utilities.Randomization" version="0.2.3" />
         <dependency id="TehGM.Utilities.Time" version="0.2.2" />
         <dependency id="TehGM.Utilities.Validation" version="0.1.0" />
         <dependency id="TehGM.Utilities.Threading" version="0.2.0" />

--- a/Tests/TehGM.Utilities.Randomization.Tests/Services/RandomizerServiceTests.cs
+++ b/Tests/TehGM.Utilities.Randomization.Tests/Services/RandomizerServiceTests.cs
@@ -36,6 +36,38 @@ namespace TehGM.Utilities.Randomization.Tests
             result.Should().BeLessThanOrEqualTo(max);
         }
 
+#if NET6_0_OR_GREATER
+        [Test]
+        [Repeat(5)]
+        [Category(nameof(RandomizerService.GetRandomNumber))]
+        public void GetRandomNumber_Int64_WithinSpecifiedRange()
+        {
+            long min = 2;
+            long max = 4;
+            RandomizerService randomizer = new RandomizerService();
+
+            long result = randomizer.GetRandomNumber(min, max, true);
+
+            result.Should().BeGreaterThanOrEqualTo(min);
+            result.Should().BeLessThanOrEqualTo(max);
+        }
+
+        [Test]
+        [Repeat(5)]
+        [Category(nameof(RandomizerService.GetRandomNumber))]
+        public void GetRandomNumber_Float_WithinSpecifiedRange()
+        {
+            float min = 2.0f;
+            float max = 4.0f;
+            RandomizerService randomizer = new RandomizerService();
+
+            float result = randomizer.GetRandomNumber(min, max);
+
+            result.Should().BeGreaterThanOrEqualTo(min);
+            result.Should().BeLessThanOrEqualTo(max);
+        }
+#endif
+
         [Test]
         [TestCase(123, 10, 9, 8)]
         [TestCase(321, 4, 0, 1)]

--- a/Tests/TehGM.Utilities.Randomization.Tests/TehGM.Utilities.Randomization.Tests.csproj
+++ b/Tests/TehGM.Utilities.Randomization.Tests/TehGM.Utilities.Randomization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/Tests/TehGM.Utilities.Randomization.Tests/TehGM.Utilities.Randomization.Tests.csproj
+++ b/Tests/TehGM.Utilities.Randomization.Tests/TehGM.Utilities.Randomization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/Tests/TehGM.Utilities.TestsBase/TehGM.Utilities.TestsBase.csproj
+++ b/Tests/TehGM.Utilities.TestsBase/TehGM.Utilities.TestsBase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>TehGM</RootNamespace>

--- a/Tests/TehGM.Utilities.TestsBase/TehGM.Utilities.TestsBase.csproj
+++ b/Tests/TehGM.Utilities.TestsBase/TehGM.Utilities.TestsBase.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <RootNamespace>TehGM</RootNamespace>

--- a/Tests/TehGM.Utilities.UniqueIDs.Tests/Base64GuidTests.cs
+++ b/Tests/TehGM.Utilities.UniqueIDs.Tests/Base64GuidTests.cs
@@ -37,6 +37,7 @@ namespace TehGM.Utilities.UniqueIDs.Tests
             result.Value.Should().Be(guid);
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         [Test]
         [TestCase("fWdQp6v36EOjBsT1a18b2Q", "a750677d-f7ab-43e8-a306-c4f56b5f1bd9")]
         [TestCase("8KVZQg08_0CJjrEnGNEixw", "4259a5f0-3c0d-40ff-898e-b12718d122c7")]
@@ -144,6 +145,7 @@ namespace TehGM.Utilities.UniqueIDs.Tests
 
             act.Should().Throw<FormatException>();
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Test]
         [Repeat(3)]

--- a/Tests/TehGM.Utilities.UniqueIDs.Tests/Base64GuidTests.cs
+++ b/Tests/TehGM.Utilities.UniqueIDs.Tests/Base64GuidTests.cs
@@ -257,7 +257,7 @@ namespace TehGM.Utilities.UniqueIDs.Tests
         {
             Action act = () => Base64Guid.Parse(input);
 
-            act.Should().Throw<FormatException>();
+            var ex = act.Should().Throw<FormatException>();
         }
 
         [Test]

--- a/Tests/TehGM.Utilities.UniqueIDs.Tests/TehGM.Utilities.UniqueIDs.Tests.csproj
+++ b/Tests/TehGM.Utilities.UniqueIDs.Tests/TehGM.Utilities.UniqueIDs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 	<IsTestProject>true</IsTestProject>

--- a/Tests/TehGM.Utilities.UniqueIDs.Tests/TehGM.Utilities.UniqueIDs.Tests.csproj
+++ b/Tests/TehGM.Utilities.UniqueIDs.Tests/TehGM.Utilities.UniqueIDs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 	<IsTestProject>true</IsTestProject>


### PR DESCRIPTION
- UniqueIDs: Base64Guid constructor accepting string is now obsolete. Use Parse method instead.
- UniqueIDs: Reduce heap allocations and improve performance of Base64Guid on .NET7+.
- UniqueIDs: Fix wrong type named used in some of Base64Guid exception messages.
- Randomization: Add support for long and float-based random number generation (.NET 6+).
- Randomization: Minor performance and heap allocation optimization for random string on .NET 7+.