### PR TITLE
Release v0.2.4

### DIFF
--- a/JsonNet/TehGM.Utilities.Time.JsonNet/TehGM.Utilities.Time.JsonNet.csproj
+++ b/JsonNet/TehGM.Utilities.Time.JsonNet/TehGM.Utilities.Time.JsonNet.csproj
@@ -4,7 +4,7 @@
 		<PackageId>TehGM.Utilities.Time.JsonNet</PackageId>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<RootNamespace>TehGM.Utilities</RootNamespace>
-		<Version>0.2.2</Version>
+		<Version>0.2.4</Version>
 		<Authors>TehGM</Authors>
 		<Product>TehGM's Utilities Library - Time - JSON.NET</Product>
 		<RepositoryUrl>https://github.com/TehGM/TehGM.Utilities</RepositoryUrl>
@@ -18,7 +18,7 @@
 		<RepositoryType>git</RepositoryType>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageReleaseNotes>- Compat with Time v0.2.2.</PackageReleaseNotes>
+		<PackageReleaseNotes>- Compat with Time v0.2.4.</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampConverter.cs
+++ b/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampConverter.cs
@@ -34,6 +34,8 @@ namespace Newtonsoft.Json.Converters
                 writer.WriteValue(new UnixTimestamp(dt).Value);
             else if (value is DateTimeOffset dto)
                 writer.WriteValue(new UnixTimestamp(dto).Value);
+            else if (value is UnixTimestampMilliseconds utms)
+                writer.WriteValue(((UnixTimestamp)utms).Value);
         }
 
         /// <inheritdoc/>
@@ -47,6 +49,8 @@ namespace Newtonsoft.Json.Converters
                 return ut.ToDateTimeOffset();
             if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
                 return ut.ToDateTime();
+            if (objectType == typeof(UnixTimestampMilliseconds) || objectType == typeof(UnixTimestampMilliseconds?))
+                return ut.Value * 1000;
             return ut;
         }
     }

--- a/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampMillisecondsConverter.cs
+++ b/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampMillisecondsConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using TehGM.Utilities;
+
+namespace Newtonsoft.Json.Converters
+{
+    /// <summary>A JSON converter that can convert <see cref="UnixTimestampMilliseconds"/>, <see cref="DateTime"/> and <see cref="DateTimeOffset"/> into unix timestamp representation (with milliseconds).</summary>
+    /// <example><code>
+    /// [JsonConverter(typeof(UnixTimestampMillisecondsConverter))]
+    /// public UnixTimestampMilliseconds Timestamp { get; set; }
+    /// [JsonConverter(typeof(UnixTimestampMillisecondsConverter))]
+    /// public DateTime DateTime { get; set; }
+    /// [JsonConverter(typeof(UnixTimestampMillisecondsConverter))]
+    /// public DateTimeOffset DateTimeOffset { get; set; }
+    /// </code></example>
+    public class UnixTimestampMillisecondsConverter : DateTimeConverterBase
+    {
+        /// <inheritdoc/>
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType == typeof(UnixTimestampMilliseconds) || objectType == typeof(UnixTimestampMilliseconds?))
+                return true;
+
+            return base.CanConvert(objectType);
+        }
+
+        /// <inheritdoc/>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+                writer.WriteNull();
+            else if (value is UnixTimestampMilliseconds ut)
+                writer.WriteValue(ut.Value);
+            else if (value is DateTime dt)
+                writer.WriteValue(new UnixTimestampMilliseconds(dt).Value);
+            else if (value is DateTimeOffset dto)
+                writer.WriteValue(new UnixTimestampMilliseconds(dto).Value);
+        }
+
+        /// <inheritdoc/>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null)
+                return null;
+
+            UnixTimestampMilliseconds ut = new UnixTimestampMilliseconds((long)reader.Value);
+            if (objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?))
+                return ut.ToDateTimeOffset();
+            if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
+                return ut.ToDateTime();
+            return ut;
+        }
+    }
+}

--- a/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampMillisecondsConverter.cs
+++ b/JsonNet/TehGM.Utilities.Time.JsonNet/UnixTimestampMillisecondsConverter.cs
@@ -28,12 +28,14 @@ namespace Newtonsoft.Json.Converters
         {
             if (value == null)
                 writer.WriteNull();
-            else if (value is UnixTimestampMilliseconds ut)
-                writer.WriteValue(ut.Value);
+            else if (value is UnixTimestampMilliseconds utms)
+                writer.WriteValue(utms.Value);
             else if (value is DateTime dt)
                 writer.WriteValue(new UnixTimestampMilliseconds(dt).Value);
             else if (value is DateTimeOffset dto)
                 writer.WriteValue(new UnixTimestampMilliseconds(dto).Value);
+            else if (value is UnixTimestamp ut)
+                writer.WriteValue(new UnixTimestampMilliseconds(ut.Value * 1000).Value);
         }
 
         /// <inheritdoc/>
@@ -42,12 +44,14 @@ namespace Newtonsoft.Json.Converters
             if (reader.Value == null)
                 return null;
 
-            UnixTimestampMilliseconds ut = new UnixTimestampMilliseconds((long)reader.Value);
+            UnixTimestampMilliseconds utms = new UnixTimestampMilliseconds((long)reader.Value);
             if (objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?))
-                return ut.ToDateTimeOffset();
+                return utms.ToDateTimeOffset();
             if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
-                return ut.ToDateTime();
-            return ut;
+                return utms.ToDateTime();
+            if (objectType == typeof(UnixTimestamp) || objectType == typeof(UnixTimestamp?))
+                return (UnixTimestamp)utms;
+            return utms;
         }
     }
 }

--- a/TehGM.Utilities.Time/TehGM.Utilities.Time.csproj
+++ b/TehGM.Utilities.Time/TehGM.Utilities.Time.csproj
@@ -4,7 +4,7 @@
 	  <PackageId>TehGM.Utilities.Time</PackageId>
       <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
 	  <RootNamespace>TehGM.Utilities</RootNamespace>
-	  <Version>0.2.2</Version>
+	  <Version>0.2.4</Version>
       <Authors>TehGM</Authors>
 	  <Product>TehGM's Utilities Library - Time</Product>
 	  <RepositoryUrl>https://github.com/TehGM/TehGM.Utilities</RepositoryUrl>
@@ -19,8 +19,8 @@
 	  <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <PackageReleaseNotes>
-- Added TypeConverter for UnixTimestamp.
-- Implement IParsable and ISpanParsable in UnixTimestamp (.NET7+).
+- Add UnixTimestampMilliseconds type with corresponding converters.
+- UnixTimestamp now supports conversions to and from the new UnixTimestampMilliseconds type.
 	  </PackageReleaseNotes>
   </PropertyGroup>
 	

--- a/TehGM.Utilities.Time/UnixTimestamp.cs
+++ b/TehGM.Utilities.Time/UnixTimestamp.cs
@@ -9,8 +9,8 @@ namespace TehGM.Utilities
     /// <summary>Represents an unix timestamp (seconds only).</summary>
     [DebuggerDisplay("{Value,nq}")]
     [TypeConverter(typeof(UnixTimestampConverter))]
-    public struct UnixTimestamp : IEquatable<UnixTimestamp>, IEquatable<long>, IEquatable<DateTime>, IEquatable<DateTimeOffset>, 
-        IComparable<UnixTimestamp>, IComparable<DateTime>, IComparable<DateTimeOffset>, IComparable<long>, IConvertible
+    public struct UnixTimestamp : IEquatable<UnixTimestamp>, IEquatable<long>, IEquatable<DateTime>, IEquatable<DateTimeOffset>, IEquatable<UnixTimestampMilliseconds>,
+        IComparable<UnixTimestamp>, IComparable<DateTime>, IComparable<DateTimeOffset>, IComparable<UnixTimestampMilliseconds>, IComparable<long>, IConvertible
 #if NET7_0_OR_GREATER
         , IParsable<UnixTimestamp>, ISpanParsable<UnixTimestamp>
 #endif
@@ -49,6 +49,8 @@ namespace TehGM.Utilities
         {
             if (obj is UnixTimestamp ut)
                 return this.Equals(ut);
+            if (obj is UnixTimestampMilliseconds utms)
+                return this.Equals(utms);
             if (obj is DateTime dt)
                 return this.Equals(dt);
             if (obj is DateTimeOffset dto)
@@ -149,6 +151,10 @@ namespace TehGM.Utilities
             => this.Equals(other.Value);
 
         /// <inheritdoc/>
+        public bool Equals(UnixTimestampMilliseconds other)
+            => (this.Value * 1000).Equals(other.Value);
+
+        /// <inheritdoc/>
         public bool Equals(long other)
             => this.Value.Equals(other);
 
@@ -213,6 +219,10 @@ namespace TehGM.Utilities
         /// <inheritdoc/>
         public int CompareTo(UnixTimestamp other)
             => this.Value.CompareTo(other.Value);
+
+        /// <inheritdoc/>
+        public int CompareTo(UnixTimestampMilliseconds other)
+            => (this.Value * 1000).CompareTo(other.Value);
 
         /// <inheritdoc/>
         public int CompareTo(DateTimeOffset other)

--- a/TehGM.Utilities.Time/UnixTimestamp.cs
+++ b/TehGM.Utilities.Time/UnixTimestamp.cs
@@ -40,7 +40,9 @@ namespace TehGM.Utilities
         /// <summary>Creates a new unix timestamp.</summary>
         /// <param name="value">DateTimeOffset to get unix timestamp from.</param>
         public UnixTimestamp(DateTimeOffset value)
-            : this(value.UtcDateTime) { }
+        {
+            this.Value = value.ToUnixTimeSeconds();
+        }
 
         /// <inheritdoc/>
         public override bool Equals(object obj)

--- a/TehGM.Utilities.Time/UnixTimestampConverter.cs
+++ b/TehGM.Utilities.Time/UnixTimestampConverter.cs
@@ -32,6 +32,8 @@ namespace TehGM.Utilities.ComponentModel
                 return new UnixTimestamp(number32);
             if (value is string str)
                 return UnixTimestamp.Parse(str, culture);
+            if (value is UnixTimestampMilliseconds)
+                return (UnixTimestamp)value;
             return base.ConvertFrom(context, culture, value);
         }
 
@@ -47,10 +49,12 @@ namespace TehGM.Utilities.ComponentModel
                 return timestamp.Value;
             if (destinationType == typeof(string))
                 return timestamp.ToString();
+            if (destinationType == typeof(UnixTimestampMilliseconds))
+                return new UnixTimestampMilliseconds(timestamp.Value * 1000);
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
         private static bool IsSupportedType(Type type)
-            => type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(long) || type == typeof(string);
+            => type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(long) || type == typeof(string) || type == typeof(UnixTimestampMilliseconds);
     }
 }

--- a/TehGM.Utilities.Time/UnixTimestampMilliseconds.cs
+++ b/TehGM.Utilities.Time/UnixTimestampMilliseconds.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using TehGM.Utilities.ComponentModel;
+
+namespace TehGM.Utilities
+{
+    /// <summary>Represents an unix timestamp (milliseconds).</summary>
+    [DebuggerDisplay("{Value,nq}")]
+    [TypeConverter(typeof(UnixTimestampMillisecondsConverter))]
+    public struct UnixTimestampMilliseconds : IEquatable<UnixTimestampMilliseconds>, IEquatable<long>, IEquatable<DateTime>, IEquatable<DateTimeOffset>, 
+        IComparable<UnixTimestampMilliseconds>, IComparable<DateTime>, IComparable<DateTimeOffset>, IComparable<long>, IConvertible
+#if NET7_0_OR_GREATER
+        , IParsable<UnixTimestampMilliseconds>, ISpanParsable<UnixTimestampMilliseconds>
+#endif
+    {
+        /// <summary>DateTime value of Unix Epoch.</summary>
+        public static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTimeOffset _epochOffset = new DateTimeOffset(Epoch);
+
+        /// <summary>Milliseconds value of the timestamp.</summary>
+        public long Value { get; }
+
+        /// <summary>Creates a new unix timestamp.</summary>
+        /// <param name="value">Raw value of the timestamp.</param>
+        public UnixTimestampMilliseconds(long value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>Creates a new unix timestamp.</summary>
+        /// <param name="value">DateTime to get unix timestamp from.</param>
+        public UnixTimestampMilliseconds(DateTime value)
+        {
+            double milliseconds = ((DateTime)value - Epoch).TotalMilliseconds;
+            this.Value = (long)milliseconds;
+        }
+
+        /// <summary>Creates a new unix timestamp.</summary>
+        /// <param name="value">DateTimeOffset to get unix timestamp from.</param>
+        public UnixTimestampMilliseconds(DateTimeOffset value)
+        {
+            this.Value = value.ToUnixTimeMilliseconds();
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is UnixTimestampMilliseconds ut)
+                return this.Equals(ut);
+            if (obj is DateTime dt)
+                return this.Equals(dt);
+            if (obj is DateTimeOffset dto)
+                return this.Equals(dto);
+            if (obj is long value)
+                return this.Equals(value);
+            return false;
+        }
+
+        /// <summary>Converts the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">String representation of UnixTimestampMilliseconds.</param>
+        /// <exception cref="ArgumentNullException">Given value is null.</exception>
+        /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        /// <returns>Parsed UnixTimestampMilliseconds value.</returns>
+        public static UnixTimestampMilliseconds Parse(string value)
+            => Parse(value, null);
+
+        /// <summary>Converts the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">String representation of UnixTimestampMilliseconds.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about value.</param>
+        /// <exception cref="ArgumentNullException">Given value is null.</exception>
+        /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        /// <returns>Parsed UnixTimestampMilliseconds value.</returns>
+        public static UnixTimestampMilliseconds Parse(string value, IFormatProvider provider)
+        {
+            long numberValue = long.Parse(value, provider);
+            return new UnixTimestampMilliseconds(numberValue);
+        }
+
+#if NET7_0_OR_GREATER
+        /// <summary>Converts the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">The span of characters to parse.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about value.</param>
+        /// <exception cref="ArgumentNullException">Given value is null.</exception>
+        /// <exception cref="FormatException">Given value is in invalid format.</exception>
+        /// <returns>Parsed UnixTimestampMilliseconds value.</returns>
+        public static UnixTimestampMilliseconds Parse(ReadOnlySpan<char> value, IFormatProvider provider)
+        {
+            long numberValue = long.Parse(value, provider);
+            return new UnixTimestampMilliseconds(numberValue);
+        }
+#endif
+
+        /// <summary>Attempts to convert the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">String representation of UnixTimestampMilliseconds.</param>
+        /// <param name="result">Parsed UnixTimestampMilliseconds value.</param>
+        public static bool TryParse(string value, out UnixTimestampMilliseconds result)
+        {
+            if (long.TryParse(value, out long numberValue))
+            {
+                result = new UnixTimestampMilliseconds(numberValue);
+                return true;
+            }
+            result = default;
+            return false;
+        }
+
+        /// <summary>Attempts to convert the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">String representation of UnixTimestampMilliseconds.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about value.</param>
+        /// <param name="result">Parsed UnixTimestampMilliseconds value.</param>
+        public static bool TryParse(string value, IFormatProvider provider, out UnixTimestampMilliseconds result)
+        {
+
+#if NET7_0_OR_GREATER
+            if (long.TryParse(value, provider, out long numberValue))
+#else
+
+            if (long.TryParse(value, System.Globalization.NumberStyles.Integer, provider, out long numberValue))
+#endif
+            {
+                result = new UnixTimestampMilliseconds(numberValue);
+                return true;
+            }
+            result = default;
+            return false;
+        }
+
+#if NET7_0_OR_GREATER
+        /// <summary>Attempts to convert the string representation of a UnixTimestampMilliseconds or Int64 to a UnixTimestampMilliseconds instance.</summary>
+        /// <param name="value">The span of characters to parse.</param>
+        /// <param name="provider">An object that provides culture-specific formatting information about value.</param>
+        /// <param name="result">Parsed UnixTimestampMilliseconds value.</param>
+        public static bool TryParse(ReadOnlySpan<char> value, IFormatProvider provider, [MaybeNullWhen(false)] out UnixTimestampMilliseconds result)
+        {
+            if (long.TryParse(value, provider, out long numberValue))
+            {
+                result = new UnixTimestampMilliseconds(numberValue);
+                return true;
+            }
+            result = default;
+            return false;
+        }
+#endif
+
+        /// <inheritdoc/>
+        public bool Equals(UnixTimestampMilliseconds other)
+            => this.Equals(other.Value);
+
+        /// <inheritdoc/>
+        public bool Equals(long other)
+            => this.Value.Equals(other);
+
+        /// <inheritdoc/>
+        public bool Equals(DateTime other)
+            => this.Equals(new UnixTimestampMilliseconds(other));
+
+        /// <inheritdoc/>
+        public bool Equals(DateTimeOffset other)
+            => this.Equals(new UnixTimestampMilliseconds(other));
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+            => -1937169414 + this.Value.GetHashCode();
+
+        /// <summary>Gets DateTime value of the timestamp.</summary>
+        public DateTime ToDateTime()
+            => Epoch.AddMilliseconds(this.Value);
+        /// <summary>Gets DateTimeOffset value of the timestamp.</summary>
+        public DateTimeOffset ToDateTimeOffset()
+            => _epochOffset.AddMilliseconds(this.Value);
+
+        /// <inheritdoc/>
+        public static bool operator ==(UnixTimestampMilliseconds left, UnixTimestampMilliseconds right)
+            => left.Equals(right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(UnixTimestampMilliseconds left, UnixTimestampMilliseconds right)
+            => !(left == right);
+
+        /// <summary>Creates a new unix timestamp.</summary>
+        /// <param name="value">DateTime to get unix timestamp from.</param>
+        public static explicit operator UnixTimestampMilliseconds(DateTime value)
+            => new UnixTimestampMilliseconds(value);
+        /// <summary>Creates a new unix timestamp.</summary>
+        /// <param name="value">DateTimeOffset to get unix timestamp from.</param>
+        public static explicit operator UnixTimestampMilliseconds(DateTimeOffset value)
+            => new UnixTimestampMilliseconds(value);
+
+        /// <summary>Gets DateTime value of the timestamp.</summary>
+        /// <param name="value">Unix timestamp.</param>
+        public static implicit operator DateTime(UnixTimestampMilliseconds value)
+            => value.ToDateTime();
+        /// <summary>Gets DateTimeOffset value of the timestamp.</summary>
+        /// <param name="value">Unix timestamp.</param>
+        public static implicit operator DateTimeOffset(UnixTimestampMilliseconds value)
+            => value.ToDateTimeOffset();
+
+        /// <inheritdoc/>
+        public override string ToString()
+            => this.Value.ToString();
+
+#region IComparable
+        /// <inheritdoc/>
+        public int CompareTo(long other)
+            => this.Value.CompareTo(other);
+
+        /// <inheritdoc/>
+        public int CompareTo(DateTime other)
+            => this.ToDateTime().CompareTo(other);
+
+        /// <inheritdoc/>
+        public int CompareTo(UnixTimestampMilliseconds other)
+            => this.Value.CompareTo(other.Value);
+
+        /// <inheritdoc/>
+        public int CompareTo(DateTimeOffset other)
+            => this.ToDateTimeOffset().CompareTo(other);
+#endregion
+
+#region IConvertible
+        /// <inheritdoc/>
+        TypeCode IConvertible.GetTypeCode()
+            => TypeCode.Int64;
+        /// <inheritdoc/>
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+            => this.ToDateTime();
+        /// <inheritdoc/>
+        decimal IConvertible.ToDecimal(IFormatProvider provider)
+            => this.Value;
+        /// <inheritdoc/>
+        double IConvertible.ToDouble(IFormatProvider provider)
+            => this.Value;
+        /// <inheritdoc/>
+        float IConvertible.ToSingle(IFormatProvider provider)
+            => this.Value;
+        /// <inheritdoc/>
+        string IConvertible.ToString(IFormatProvider provider)
+            => this.ToString();
+        /// <inheritdoc/>
+        long IConvertible.ToInt64(IFormatProvider provider)
+            => this.Value;
+        /// <inheritdoc/>
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+            => (ulong)this.Value;
+        /// <inheritdoc/>
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(Boolean).FullName}");
+        /// <inheritdoc/>
+        byte IConvertible.ToByte(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(Byte).FullName}");
+        /// <inheritdoc/>
+        char IConvertible.ToChar(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(Char).FullName}");
+        /// <inheritdoc/>
+        short IConvertible.ToInt16(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(Int16).FullName}");
+        /// <inheritdoc/>
+        int IConvertible.ToInt32(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(Int32).FullName}");
+        /// <inheritdoc/>
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(SByte).FullName}");
+        /// <inheritdoc/>
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(UInt16).FullName}");
+        /// <inheritdoc/>
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+            => throw new InvalidCastException($"Cannot cast {this.GetType().FullName} to {typeof(UInt32).FullName}");
+
+        /// <inheritdoc/>
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            if (conversionType.IsAssignableFrom(this.GetType()))
+                return this;
+            return Convert.ChangeType(this.Value, conversionType);
+        }
+#endregion
+    }
+}

--- a/TehGM.Utilities.Time/UnixTimestampMilliseconds.cs
+++ b/TehGM.Utilities.Time/UnixTimestampMilliseconds.cs
@@ -9,8 +9,8 @@ namespace TehGM.Utilities
     /// <summary>Represents an unix timestamp (milliseconds).</summary>
     [DebuggerDisplay("{Value,nq}")]
     [TypeConverter(typeof(UnixTimestampMillisecondsConverter))]
-    public struct UnixTimestampMilliseconds : IEquatable<UnixTimestampMilliseconds>, IEquatable<long>, IEquatable<DateTime>, IEquatable<DateTimeOffset>, 
-        IComparable<UnixTimestampMilliseconds>, IComparable<DateTime>, IComparable<DateTimeOffset>, IComparable<long>, IConvertible
+    public struct UnixTimestampMilliseconds : IEquatable<UnixTimestampMilliseconds>, IEquatable<long>, IEquatable<DateTime>, IEquatable<DateTimeOffset>, IEquatable<UnixTimestamp>,
+        IComparable<UnixTimestampMilliseconds>, IComparable<UnixTimestamp>, IComparable<DateTime>, IComparable<DateTimeOffset>, IComparable<long>, IConvertible
 #if NET7_0_OR_GREATER
         , IParsable<UnixTimestampMilliseconds>, ISpanParsable<UnixTimestampMilliseconds>
 #endif
@@ -47,7 +47,9 @@ namespace TehGM.Utilities
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj is UnixTimestampMilliseconds ut)
+            if (obj is UnixTimestampMilliseconds utms)
+                return this.Equals(utms);
+            if (obj is UnixTimestamp ut)
                 return this.Equals(ut);
             if (obj is DateTime dt)
                 return this.Equals(dt);
@@ -149,6 +151,10 @@ namespace TehGM.Utilities
             => this.Equals(other.Value);
 
         /// <inheritdoc/>
+        public bool Equals(UnixTimestamp other)
+            => this.Equals(other.Value * 1000);
+
+        /// <inheritdoc/>
         public bool Equals(long other)
             => this.Value.Equals(other);
 
@@ -179,14 +185,18 @@ namespace TehGM.Utilities
         public static bool operator !=(UnixTimestampMilliseconds left, UnixTimestampMilliseconds right)
             => !(left == right);
 
-        /// <summary>Creates a new unix timestamp.</summary>
+        /// <summary>Creates a new unix timestamp with milliseconds precision.</summary>
         /// <param name="value">DateTime to get unix timestamp from.</param>
         public static explicit operator UnixTimestampMilliseconds(DateTime value)
             => new UnixTimestampMilliseconds(value);
-        /// <summary>Creates a new unix timestamp.</summary>
+        /// <summary>Creates a new unix timestamp with milliseconds precision.</summary>
         /// <param name="value">DateTimeOffset to get unix timestamp from.</param>
         public static explicit operator UnixTimestampMilliseconds(DateTimeOffset value)
             => new UnixTimestampMilliseconds(value);
+        /// <summary>Creates a new unix timestamp with milliseconds precision.</summary>
+        /// <param name="value">UnixTimestamp to get unix timestamp from.</param>
+        public static implicit operator UnixTimestampMilliseconds(UnixTimestamp value)
+            => new UnixTimestampMilliseconds(value.Value * 1000);
 
         /// <summary>Gets DateTime value of the timestamp.</summary>
         /// <param name="value">Unix timestamp.</param>
@@ -196,6 +206,10 @@ namespace TehGM.Utilities
         /// <param name="value">Unix timestamp.</param>
         public static implicit operator DateTimeOffset(UnixTimestampMilliseconds value)
             => value.ToDateTimeOffset();
+        /// <summary>Gets UnixTimestamp value of the timestamp.</summary>
+        /// <param name="value">Unix timestamp.</param>
+        public static explicit operator UnixTimestamp(UnixTimestampMilliseconds value)
+            => new UnixTimestamp(value.ToDateTime());
 
         /// <inheritdoc/>
         public override string ToString()
@@ -213,6 +227,10 @@ namespace TehGM.Utilities
         /// <inheritdoc/>
         public int CompareTo(UnixTimestampMilliseconds other)
             => this.Value.CompareTo(other.Value);
+
+        /// <inheritdoc/>
+        public int CompareTo(UnixTimestamp other)
+            => this.Value.CompareTo(other.Value * 1000);
 
         /// <inheritdoc/>
         public int CompareTo(DateTimeOffset other)

--- a/TehGM.Utilities.Time/UnixTimestampMillisecondsConverter.cs
+++ b/TehGM.Utilities.Time/UnixTimestampMillisecondsConverter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace TehGM.Utilities.ComponentModel
+{
+    /// <summary>Provides a type converter to convert <see cref="UnixTimestampMilliseconds"/> objects to and from various other representations.</summary>
+    public class UnixTimestampMillisecondsConverter : TypeConverter
+    {
+        /// <inheritdoc/>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return IsSupportedType(sourceType) || sourceType == typeof(int) || base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return IsSupportedType(destinationType) || base.CanConvertTo(context, destinationType);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is DateTime dt)
+                return new UnixTimestampMilliseconds(dt);
+            if (value is DateTimeOffset dto)
+                return new UnixTimestampMilliseconds(dto);
+            if (value is long number64)
+                return new UnixTimestampMilliseconds(number64);
+            if (value is int number32)
+                return new UnixTimestampMilliseconds(number32);
+            if (value is string str)
+                return UnixTimestampMilliseconds.Parse(str, culture);
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <inheritdoc/>
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            UnixTimestampMilliseconds timestamp = (UnixTimestampMilliseconds)value;
+            if (destinationType == typeof(DateTime))
+                return timestamp.ToDateTime();
+            if (destinationType == typeof(DateTimeOffset))
+                return timestamp.ToDateTimeOffset();
+            if (destinationType == typeof(long))
+                return timestamp.Value;
+            if (destinationType == typeof(string))
+                return timestamp.ToString();
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        private static bool IsSupportedType(Type type)
+            => type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(long) || type == typeof(string);
+    }
+}

--- a/TehGM.Utilities.Time/UnixTimestampMillisecondsConverter.cs
+++ b/TehGM.Utilities.Time/UnixTimestampMillisecondsConverter.cs
@@ -32,6 +32,8 @@ namespace TehGM.Utilities.ComponentModel
                 return new UnixTimestampMilliseconds(number32);
             if (value is string str)
                 return UnixTimestampMilliseconds.Parse(str, culture);
+            if (value is UnixTimestamp ut)
+                return new UnixTimestampMilliseconds(ut.Value * 1000);
             return base.ConvertFrom(context, culture, value);
         }
 
@@ -47,10 +49,12 @@ namespace TehGM.Utilities.ComponentModel
                 return timestamp.Value;
             if (destinationType == typeof(string))
                 return timestamp.ToString();
+            if (destinationType == typeof(UnixTimestamp))
+                return (UnixTimestamp)timestamp;
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
         private static bool IsSupportedType(Type type)
-            => type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(long) || type == typeof(string);
+            => type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(long) || type == typeof(string) || type == typeof(UnixTimestampMilliseconds);
     }
 }

--- a/TehGM.Utilities/TehGM.Utilities.nuspec
+++ b/TehGM.Utilities/TehGM.Utilities.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>TehGM.Utilities</id>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <title>TehGM's C# Utilities</title>
     <authors>TehGM</authors>
     <owners>TehGM</owners>
@@ -14,18 +14,15 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <copyright>Copyright (c) 2022 TehGM</copyright>
     <releaseNotes>
-- UniqueIDs: Base64Guid constructor accepting string is now obsolete. Use Parse method instead.
-- UniqueIDs: Reduce heap allocations and improve performance of Base64Guid on .NET7+.
-- UniqueIDs: Fix wrong type named used in some of Base64Guid exception messages.
-- Randomization: Add support for long and float-based random number generation (.NET 6+).
-- Randomization: Minor performance and heap allocation optimization for random string on .NET 7+.
+- Time: Add UnixTimestampMilliseconds type with corresponding converters.
+- Time: UnixTimestamp now supports conversions to and from the new UnixTimestampMilliseconds type.
 	</releaseNotes>
     <dependencies>
       <group>
         <dependency id="TehGM.Utilities.UniqueID" version="0.2.3" />
         <dependency id="TehGM.Utilities.Logging" version="0.1.0" />
         <dependency id="TehGM.Utilities.Randomization" version="0.2.3" />
-        <dependency id="TehGM.Utilities.Time" version="0.2.2" />
+        <dependency id="TehGM.Utilities.Time" version="0.2.4" />
         <dependency id="TehGM.Utilities.Validation" version="0.1.0" />
         <dependency id="TehGM.Utilities.Threading" version="0.2.0" />
       </group>

--- a/Tests/TehGM.Utilities.Time.Tests/UnixTimestampMillisecondsTests.cs
+++ b/Tests/TehGM.Utilities.Time.Tests/UnixTimestampMillisecondsTests.cs
@@ -1,0 +1,137 @@
+namespace TehGM.Utilities.Time.Tests
+{
+    [TestFixture]
+    [TestOf(typeof(UnixTimestampMilliseconds))]
+    public class UnixTimestampMillisecondsTests : TestBase
+    {
+        [Test, AutoNSubstituteData]
+        [Repeat(3)]
+        [Category(TestCategoryName.Constructor)]
+        public void Constructor_FromValue_KeepsOriginalValue(long value)
+        {
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(value);
+
+            timestamp.Value.Should().Be(value);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 1656002616746)]
+        [TestCase(629474418000000000, 811845000000)]
+        [TestCase(630593244022000000, 923727602200)]
+        [Category(TestCategoryName.Constructor)]
+        public void Constructor_FromDateTime_ConvertsValue(long ticks, long expectedResult)
+        {
+            DateTime dt = new DateTime(ticks);
+
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dt);
+
+            timestamp.Value.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 1656002616746)]
+        [TestCase(629474418000000000, 811845000000)]
+        [TestCase(630593244022000000, 923727602200)]
+        [Category(TestCategoryName.Conversions)]
+        public void ExplicitConversion_FromDateTime_ConvertsValue(long ticks, long expectedResult)
+        {
+            DateTime dt = new DateTime(ticks);
+
+            UnixTimestampMilliseconds timestamp = (UnixTimestampMilliseconds)dt;
+
+            timestamp.Value.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 1656002616746)]
+        [TestCase(629474418000000000, 811845000000)]
+        [TestCase(630593244022000000, 923727602200)]
+        [Category(TestCategoryName.Constructor)]
+        public void Constructor_FromDateTimeOffset_ConvertsValue(long ticks, long expectedResult)
+        {
+            DateTimeOffset dto = new DateTimeOffset(ticks, TimeSpan.Zero);
+
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dto);
+
+            timestamp.Value.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 1656002616746)]
+        [TestCase(629474418000000000, 811845000000)]
+        [TestCase(630593244022000000, 923727602200)]
+        [Category(TestCategoryName.Conversions)]
+        public void ExplicitConversion_FromDateTimeOffset_ConvertsValue(long ticks, long expectedResult)
+        {
+            DateTimeOffset dto = new DateTimeOffset(ticks, TimeSpan.Zero);
+
+            UnixTimestampMilliseconds timestamp = (UnixTimestampMilliseconds)dto;
+
+            timestamp.Value.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 637915994167460000)]
+        [TestCase(629474418000000000, 629474418000000000)]
+        [TestCase(630593244022000000, 630593244022000000)]
+        [Category(nameof(UnixTimestampMilliseconds.ToDateTime))]
+        public void ToDateTime_ReturnsExpectedValue(long ticks, long expectedResultTicks)
+        {
+            DateTime dt = new DateTime(ticks);
+            DateTime expectedResult = new DateTime(expectedResultTicks);
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dt);
+
+            DateTime result = timestamp.ToDateTime();
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 637915994167460000)]
+        [TestCase(629474418000000000, 629474418000000000)]
+        [TestCase(630593244022000000, 630593244022000000)]
+        [Category(TestCategoryName.Conversions)]
+        public void ImplicitConversion_ToDateTime_ReturnsExpectedValue(long ticks, long expectedResultTicks)
+        {
+            DateTime dt = new DateTime(ticks);
+            DateTime expectedResult = new DateTime(expectedResultTicks);
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dt);
+
+            DateTime result = timestamp;
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 637915994167460000)]
+        [TestCase(629474418000000000, 629474418000000000)]
+        [TestCase(630593244022000000, 630593244022000000)]
+        [Category(nameof(UnixTimestampMilliseconds.ToDateTimeOffset))]
+        public void ToDateTimeOffset_ReturnsExpectedValue(long ticks, long expectedResultTicks)
+        {
+            DateTimeOffset dto = new DateTimeOffset(ticks, TimeSpan.Zero);
+            DateTimeOffset expectedResult = new DateTimeOffset(expectedResultTicks, TimeSpan.Zero);
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dto);
+
+            DateTimeOffset result = timestamp.ToDateTimeOffset();
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(637915994167465978, 637915994167460000)]
+        [TestCase(629474418000000000, 629474418000000000)]
+        [TestCase(630593244022000000, 630593244022000000)]
+        [Category(TestCategoryName.Conversions)]
+        public void ImplicitConversions_ToDateTimeOffset_ReturnsExpectedValue(long ticks, long expectedResultTicks)
+        {
+            DateTimeOffset dto = new DateTimeOffset(ticks, TimeSpan.Zero);
+            DateTimeOffset expectedResult = new DateTimeOffset(expectedResultTicks, TimeSpan.Zero);
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dto);
+
+            DateTimeOffset result = timestamp;
+
+            result.Should().Be(expectedResult);
+        }
+    }
+}

--- a/Tests/TehGM.Utilities.Time.Tests/UnixTimestampMillisecondsTests.cs
+++ b/Tests/TehGM.Utilities.Time.Tests/UnixTimestampMillisecondsTests.cs
@@ -71,6 +71,20 @@ namespace TehGM.Utilities.Time.Tests
         }
 
         [Test]
+        [TestCase(1656002616, 1656002616000)]
+        [TestCase(811845000, 811845000000)]
+        [TestCase(923727602, 923727602000)]
+        [Category(TestCategoryName.Conversions)]
+        public void ImplicitConversion_FromUnixTimestamp_ConvertsValue(long value, long expectedResult)
+        {
+            UnixTimestamp ut = new UnixTimestamp(value);
+
+            UnixTimestampMilliseconds timestamp = ut;
+
+            timestamp.Value.Should().Be(expectedResult);
+        }
+
+        [Test]
         [TestCase(637915994167465978, 637915994167460000)]
         [TestCase(629474418000000000, 629474418000000000)]
         [TestCase(630593244022000000, 630593244022000000)]
@@ -130,6 +144,21 @@ namespace TehGM.Utilities.Time.Tests
             UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(dto);
 
             DateTimeOffset result = timestamp;
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Test]
+        [TestCase(1656002616746, 1656002616)]
+        [TestCase(811845000000, 811845000)]
+        [TestCase(923727602200, 923727602)]
+        [Category(TestCategoryName.Conversions)]
+        public void ExplicitConversions_ToUnixTimestamp_ReturnsExpectedValue(long value, long expectedResult)
+        {
+            UnixTimestamp ut = new UnixTimestamp(expectedResult);
+            UnixTimestampMilliseconds timestamp = new UnixTimestampMilliseconds(value);
+
+            UnixTimestamp result = (UnixTimestamp)timestamp;
 
             result.Should().Be(expectedResult);
         }


### PR DESCRIPTION
- Add `UnixTimestampMilliseconds` type with corresponding converters.
- `UnixTimestamp` now supports conversions to and from the new `UnixTimestampMilliseconds` type.